### PR TITLE
Add MultiSessionStore for multiple states

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,30 @@ app.get('/cb',
   });
 ```
 
+#### Multiple Concurrent States
+
+The strategy stores a unique state value in the session when initiating an
+authentication request.  Applications that need to maintain more than one
+outstanding request (for example, across multiple browser tabs) can use a
+`MultiSessionStore`:
+
+```js
+var MultiSessionStore = require('passport-openidconnect/state/multi-session');
+
+passport.use(new OpenIDConnectStrategy({
+  issuer: 'https://server.example.com',
+  authorizationURL: 'https://server.example.com/authorize',
+  tokenURL: 'https://server.example.com/token',
+  clientID: process.env['CLIENT_ID'],
+  callbackURL: 'https://client.example.org/cb',
+  store: new MultiSessionStore({ key: 'openidconnect:server.example.com' })
+}, verify));
+```
+
+`MultiSessionStore` keeps states in `req.session[options.key].states`, keyed by
+the state handle.  When a `state` value is supplied to `authenticate()`, that
+value will be used as the handle.
+
 ## Examples
 
 * [todos-express-openidconnect](https://github.com/passport/todos-express-openidconnect)

--- a/lib/state/multi-session.js
+++ b/lib/state/multi-session.js
@@ -1,0 +1,94 @@
+var utils = require('../utils');
+
+/**
+ * Creates an instance of `MultiSessionStore`.
+ *
+ * This state store supports multiple concurrent authorization requests by
+ * storing state objects in `req.session[options.key].states`, keyed by handle.
+ *
+ * Options:
+ *   - `key`  The key in the session under which to store state
+ *
+ * @constructor
+ * @param {Object} options
+ * @api public
+ */
+function MultiSessionStore(options) {
+  if (!options.key) { throw new TypeError('Session-based state store requires a session key'); }
+  this._key = options.key;
+}
+
+/**
+ * Store request state.
+ *
+ * The provided `appState`, if specified, is used as the handle.  Otherwise,
+ * a handle is generated using a uid.
+ *
+ * @param {Object} req
+ * @param {Object} ctx
+ * @param {String} appState
+ * @param {Object} meta
+ * @param {Function} cb
+ * @api protected
+ */
+MultiSessionStore.prototype.store = function(req, ctx, appState, meta, cb) {
+  if (!req.session) { return cb(new Error('OpenID Connect requires session support. Did you forget to use `express-session` middleware?')); }
+
+  var key = this._key;
+  var handle = appState || utils.uid(24);
+
+  var state = { handle: handle };
+  if (ctx.maxAge) { state.maxAge = ctx.maxAge; }
+  if (ctx.nonce) { state.nonce = ctx.nonce; }
+  if (ctx.issued) { state.issued = ctx.issued; }
+  if (appState) { state.state = appState; }
+
+  if (!req.session[key]) { req.session[key] = {}; }
+  if (!req.session[key].states) { req.session[key].states = {}; }
+  req.session[key].states[handle] = state;
+
+  cb(null, handle);
+};
+
+/**
+ * Verify request state.
+ *
+ * @param {Object} req
+ * @param {String} handle
+ * @param {Function} cb
+ * @api protected
+ */
+MultiSessionStore.prototype.verify = function(req, handle, cb) {
+  if (!req.session) { return cb(new Error('OpenID Connect requires session support. Did you forget to use `express-session` middleware?')); }
+
+  var key = this._key;
+  if (!req.session[key] || !req.session[key].states) {
+    return cb(null, false, { message: 'Unable to verify authorization request state.' });
+  }
+
+  var state = req.session[key].states[handle];
+  if (!state) {
+    return cb(null, false, { message: 'Invalid authorization request state.' });
+  }
+
+  delete req.session[key].states[handle];
+  if (Object.keys(req.session[key].states).length === 0) {
+    delete req.session[key].states;
+  }
+  if (Object.keys(req.session[key]).length === 0) {
+    delete req.session[key];
+  }
+
+  var ctx = {
+    maxAge: state.maxAge,
+    nonce: state.nonce,
+    issued: state.issued
+  };
+  if (typeof ctx.issued === 'string') {
+    ctx.issued = new Date(ctx.issued);
+  }
+
+  return cb(null, ctx, state.state);
+};
+
+module.exports = MultiSessionStore;

--- a/test/store/multi-session.test.js
+++ b/test/store/multi-session.test.js
@@ -1,0 +1,51 @@
+var MultiSessionStore = require('../../lib/state/multi-session');
+
+describe('MultiSessionStore', function() {
+  describe('multiple concurrent states', function() {
+    it('should store and verify multiple states independently', function(done) {
+      var store = new MultiSessionStore({ key: 'openidconnect:example' });
+      var req = { session: {} };
+      var ctx = {};
+
+      store.store(req, ctx, null, {}, function(err, h1) {
+        if (err) { return done(err); }
+        store.store(req, ctx, null, {}, function(err, h2) {
+          if (err) { return done(err); }
+
+          expect(Object.keys(req.session['openidconnect:example'].states)).to.have.length(2);
+
+          store.verify(req, h1, function(err, ctx1, state1) {
+            if (err) { return done(err); }
+            expect(req.session['openidconnect:example'].states).to.not.have.property(h1);
+            expect(req.session['openidconnect:example'].states).to.have.property(h2);
+
+            store.verify(req, h2, function(err, ctx2, state2) {
+              if (err) { return done(err); }
+              expect(req.session['openidconnect:example']).to.be.undefined;
+              done();
+            });
+          });
+        });
+      });
+    }); // should store and verify multiple states independently
+
+    it('should use provided state value as handle', function(done) {
+      var store = new MultiSessionStore({ key: 'openidconnect:example' });
+      var req = { session: {} };
+      var ctx = {};
+
+      store.store(req, ctx, 'custom', {}, function(err, handle) {
+        if (err) { return done(err); }
+        expect(handle).to.equal('custom');
+        expect(req.session['openidconnect:example'].states).to.have.property('custom');
+
+        store.verify(req, 'custom', function(err, ctx2, state) {
+          if (err) { return done(err); }
+          expect(state).to.equal('custom');
+          expect(req.session['openidconnect:example']).to.be.undefined;
+          done();
+        });
+      });
+    }); // should use provided state value as handle
+  }); // multiple concurrent states
+});


### PR DESCRIPTION
## Summary
- add new `MultiSessionStore` state store module
- document usage via strategy `store` option
- test that multiple states can coexist and be verified independently

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a1482f0a0832eb0cc3fdec8bd37e1